### PR TITLE
新增几种常用路径格式

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
+import { Buffer } from 'buffer';
+import { createHash } from 'crypto';
 import { IFtpLoaderPathInfo } from './config'
 import { IImgInfo } from 'picgo/dist/src/types'
-import crypto from 'crypto'
 
 export const formatPath = (
   output: IImgInfo,
@@ -12,8 +13,8 @@ export const formatPath = (
   let hashCache = { md5: null, sha1: null, sha256: null };
   const hash = function (algorithm) {
       if (!hashCache[algorithm]) {
-          hashCache[algorithm] = crypto.createHash(algorithm).update(
-            output.base64Image ? output.base64Image : output.buffer.toString()
+          hashCache[algorithm] = createHash(algorithm).update(
+            output.base64Image ? Buffer.from(output.base64Image, 'base64') : output.buffer
           ).digest('hex');
       }
       return hashCache[algorithm];


### PR DESCRIPTION
| 名称          | 介绍                   | 输出示例                                                     |
| ------------- | ---------------------- | ------------------------------------------------------------ |
| {day}         | 当前日期               | 31                                                           |
| {timestamp}         | 时间戳              | 1640174041                                                           |
| {md5sum}      | 图片 MD5 32 位         | 68559cae1081d6836e09b043aa0b3af1                             |
| {sha1sum}     | 图片 SHA1 40 位        | e0c9035898dd52fc65c41454cec9c4d2611bfb37                     |
| {sha256sum}   | 图片 SHA256 64 位      | 9ca030bdec6e900a7ac41fef448a0872a3530443c776383cf69e55916f3ad35f |
| {sha256sum:0:2}  | 起始 结束        | 9c|
         

支持 md5sum、sha1sum、sha256sum，同时支持 {sum:indexStart:indexEnd} 子串格式。

以便于支持 `{md5sum:0:2}/{md5sum:2:4}/{md5sum}{ext}` 这种散列目录格式，防止单一目录出现太多文件。