### PR TITLE
解决 URL 上传时部分 jpg 后缀图片出现变成 jpeg 后缀的bug，例如文件名：154848x9rs296aca6eii44.jp…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,9 +94,14 @@ export = (ctx: picgo) => {
       }
 
       let fname = output.fileName
-
-      if (path.extname(fname) !== output.extname) {
-        fname = fname + output.extname
+      
+      let extname = fname.match(/\.[^.]+$/ig);
+      if (extname) { //文件名有后缀
+        output.extname = extname[0];
+        pathInfo = util_1.formatPath(output, configItem[userConfig.site]); //为了避免出现jpg和gpeg后缀的问题，例如：154848x9rs296aca6eii44.jpg_1668137293.jpeg 
+      }
+      else { //无后缀
+        fname = fname + output.extname;
       }
 
       localPath = path.join(ctx.baseDir, fname)


### PR DESCRIPTION
同样的图片，通过本地上传没有异常，但通过URL上传时文件格式被picgo识别为jpeg，造成原后缀名jpg被当做文件名的一部分，例如 154848x9rs296aca6eii44.jpg 通过 URL 上传后文件名变为：
154848x9rs296aca6eii44.jpg_1668137293.jpeg（加了时间戳）

经过本次修复，文件名会是：154848x9rs296aca6eii44_1668137293.jpg